### PR TITLE
Fix: Corrects typo in Template interface

### DIFF
--- a/frontend/src/services/templateApi.ts
+++ b/frontend/src/services/templateApi.ts
@@ -2,8 +2,8 @@ import api from './api';
 
 export interface Template {
   id_modele: number;
-  nom_modele: str;
-  contenu_modele: str;
+  nom_modele: string;
+  contenu_modele: string;
   variables: Record<string, string> | null;
   created_by: number;
 }


### PR DESCRIPTION
This commit fixes a TypeScript compilation error in `frontend/src/services/templateApi.ts`.

In the `Template` interface, the type `str` was used for the `nom_modele` and `contenu_modele` fields. This is not a valid TypeScript type and has been corrected to `string`.